### PR TITLE
fix(http_client): 修复 HTTP 推送 SendRequest 永久阻塞导致 hookSyncMsg 中断的问题

### DIFF
--- a/src/http_client.cc
+++ b/src/http_client.cc
@@ -3,38 +3,49 @@
 namespace wxhelper {
 
  void HttpClient::SendRequest(std::string content) {
-    struct mg_mgr mgr;                
+    struct mg_mgr mgr;
     Data data ;
     data.done = false;
-    data.post_data = content;    
-    mg_mgr_init(&mgr);              
-    mg_http_connect(&mgr, url_.c_str(), OnHttpEvent, &data);  
+    data.post_data = content;
+    mg_mgr_init(&mgr);
+    mg_http_connect(&mgr, url_.c_str(), OnHttpEvent, &data);
     while (!data.done){
-        mg_mgr_poll(&mgr, 500);      
+        mg_mgr_poll(&mgr, 500);
     }
-    mg_mgr_free(&mgr);                        
+    mg_mgr_free(&mgr);
 }
 
 
  void HttpClient::OnHttpEvent(struct mg_connection *c, int ev, void *ev_data, void *fn_data) {
   const char * s_url = GetInstance().url_.c_str();
-  Data data = *(Data*)fn_data;
+  // 注意：这里必须用指针，不能按值拷贝 Data —— 拷贝出来的是独立副本，
+  // 后面对 data->done 的赋值只会修改副本，SendRequest 里 while(!data->done)
+  // 永远等不到 true，调用线程会被永久阻塞在 mg_mgr_poll 死循环里。
+  Data *data = (Data *)fn_data;
   if (ev == MG_EV_OPEN) {
-    // Connection created. Store connect expiration time in c->data
+    // Connection created. Store request expiration time in c->data.
+    // 这个时间戳之后会在 MG_EV_CONNECT 里重置，这里先给连接阶段一个保底超时。
     *(uint64_t *) c->data = mg_millis() + GetInstance().timeout_;
   } else if (ev == MG_EV_POLL) {
-    if (mg_millis() > *(uint64_t *) c->data &&
-        (c->is_connecting || c->is_resolving)) {
-      mg_error(c, "Connect timeout");
+    // 之前这里只在 c->is_connecting || c->is_resolving 时才判断超时，
+    // 导致 TCP 连上之后如果对端一直不回响应，会永久阻塞在这条连接上
+    // （而 SendRequest 是同步等待 data->done 的，相当于把调用线程也一起卡死）。
+    // 这里去掉这个限制，让"已连接但响应迟迟不来"同样会被判定为超时并主动断开。
+    if (mg_millis() > *(uint64_t *) c->data) {
+      mg_error(c, "Request timeout");
     }
   } else if (ev == MG_EV_CONNECT) {
+    // 连接建立后重新计时，给"等待响应"阶段一个完整的超时窗口，
+    // 避免域名解析/TCP 握手耗时过长把等待响应的预算提前吃掉。
+    *(uint64_t *) c->data = mg_millis() + GetInstance().timeout_;
+
     struct mg_str host = mg_url_host(s_url);
     if (mg_url_is_ssl(s_url)) {
       // no implement
     }
-   
+
     // Send request
-    size_t content_length = data.post_data.size();
+    size_t content_length = data->post_data.size();
     mg_printf(c,
               "POST %s HTTP/1.0\r\n"
               "Host: %.*s\r\n"
@@ -43,7 +54,7 @@ namespace wxhelper {
               "\r\n",
               mg_url_uri(s_url), (int) host.len,
               host.ptr, content_length);
-   mg_send(c, data.post_data.c_str(), content_length);
+   mg_send(c, data->post_data.c_str(), content_length);
   } else if (ev == MG_EV_HTTP_MSG) {
     // Response is received. Print it
     #ifdef _DEBUG
@@ -51,9 +62,9 @@ namespace wxhelper {
       printf("%.*s", (int) hm->message.len, hm->message.ptr);
     #endif
     c->is_closing = 1;         // Tell mongoose to close this connection
-    data.done = true;  // Tell event loop to stops
+    data->done = true;  // Tell event loop to stops
   } else if (ev == MG_EV_ERROR) {
-    data.done = true;  // Error, tell event loop to stop
+    data->done = true;  // Error, tell event loop to stop
   }
 }
 


### PR DESCRIPTION
## 问题

使用 `hookSyncMsg(enableHttp=1)` 通过 HTTP 推送消息时，运行一段时间后会出现"消息推送彻底停止"的现象，表现得像 hook 被断开，但实际上微信进程内的 hook（detour）依然生效，只是消息再也推不出来了。

## 根因

`HttpClient::OnHttpEvent` 里这一行是**按值拷贝**：

```cpp
Data data = *(Data*)fn_data;
```

`SendRequest` 通过 `&data`（栈上的 `Data` 对象）把指针传给 `mg_http_connect`，但事件回调里却把它整个拷贝成一个独立的局部副本（每次事件触发都要拷贝一遍包含 `std::string post_data` 的结构体，开销也不小）。后续：

```cpp
} else if (ev == MG_EV_HTTP_MSG) {
    c->is_closing = 1;
    data.done = true;   // 改的是局部副本，不是 SendRequest 里的那个
} else if (ev == MG_EV_ERROR) {
    data.done = true;   // 同样只改了局部副本
}
```

只修改了局部副本的 `done`，`SendRequest` 里真正在判断的 `while (!data.done)` 永远等不到 `true`——**调用线程会被永久阻塞在 `mg_mgr_poll` 死循环里，即便请求成功收到了响应**。

`HttpClient::SendRequest` 是在 `ThreadPool`（`global_context.cc` 里创建，`min=2, max=8`）的工作线程里被调用的。每成功推送一次消息就会"消耗"一个线程且永不归还，大约推送 `max` 条消息之后所有线程全部卡死，后续 `AddWork` 提交的推送任务永远得不到执行——从外部看就是"hookSyncMsg 用一会儿就断了"。

顺带还修了一个关联问题：`MG_EV_POLL` 里的超时判断只在 `c->is_connecting || c->is_resolving` 为真时才生效，TCP 连接建立之后如果对端一直不回响应，永远不会超时——同样会让调用线程永久卡住。现在改成连接建立后重新计时，且任意阶段超时都会主动断开。

## 修改

- `Data data = ...`（拷贝） → `Data *data = (Data*)fn_data;`（指针），相应地把所有 `data.xxx` 改成 `data->xxx`，确保事件回调真正能修改到 `SendRequest` 里的状态。
- `MG_EV_POLL` 的超时判断去掉 `c->is_connecting || c->is_resolving` 限制，覆盖"已连接但响应迟迟不来"的情况；并在 `MG_EV_CONNECT` 时重新计时，给等待响应阶段一个完整的超时窗口。

## 验证

已经在 GitHub Actions（windows-2022 + vcpkg + CMake/Ninja，x64 Release）编译通过，产出可用的 `wxhelper.dll`：
https://github.com/ComeyLi/wxhelper/actions/runs/27144016566

实机注入运行验证还在进行中，会在确认效果后跟进反馈；这里先把代码层面的根因分析和修复提出来供讨论。